### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ if sys.argv[-1] == 'publish':
         raise ImportError("Fix: pip install wheel")
     system('python setup.py sdist bdist_wheel upload')
     print("You probably want to also tag the version now:")
-    print("  git tag -a %s -m 'version %s'" % (version, version))
+    print("  git tag -a {0!s} -m 'version {1!s}'".format(version, version))
     print("  git push --tags")
     sys.exit()
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")
-    system("git tag -a %s -m 'version %s'" % (version, version))
+    system("git tag -a {0!s} -m 'version {1!s}'".format(version, version))
     system("git push --tags")
     sys.exit()
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ad-m:python-anticaptcha?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:ad-m:python-anticaptcha?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)