### PR TITLE
Migrate build system from setuptools to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "python-anticaptcha"
@@ -33,11 +33,12 @@ async = ["httpx>=0.24"]
 tests = ["pytest", "pytest-asyncio", "httpx>=0.24", "retry", "selenium"]
 docs = ["sphinx", "sphinx-rtd-theme"]
 
-[tool.setuptools.package-data]
-python_anticaptcha = ["py.typed"]
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "0.0.0"
 
-[tool.setuptools-scm]
-fallback_version = "0.0.0"
+[tool.hatch.build.targets.wheel]
+packages = ["python_anticaptcha"]
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
## Summary
This PR migrates the project's build system from setuptools to hatchling, modernizing the build configuration and dependency management.

## Key Changes
- **Build backend**: Switched from `setuptools.build_meta` to `hatchling.build`
- **Build dependencies**: Replaced `setuptools>=64` and `setuptools-scm>=8` with `hatchling` and `hatch-vcs`
- **Version management**: Migrated from `[tool.setuptools-scm]` to `[tool.hatch.version]` configuration with VCS-based versioning
- **Package configuration**: Moved package data configuration from `[tool.setuptools.package-data]` to `[tool.hatch.build.targets.wheel]`
- **Fallback version**: Maintained fallback version `0.0.0` for builds without VCS metadata

## Implementation Details
The migration preserves all existing functionality while adopting hatchling's configuration format. The `py.typed` marker file is now included through hatchling's wheel target configuration, and version management continues to use VCS information with the same fallback behavior.

https://claude.ai/code/session_01Wwr1CDbtn58p2EAohRFB5z